### PR TITLE
Functions to extract geometry centroids

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -53,6 +53,13 @@ AG.transform!(v::Vector{AG.IGeometry{T}}, d) where {T} = AG.buffer.(v, d)
 AG.geomlength(v::Vector{AG.IGeometry{T}}) where {T} = AG.geomlength.(v)
 AG.geomarea(v::Vector{AG.IGeometry{T}}) where {T} = AG.geomarea.(v)
 AG.centroid(v::Vector{AG.IGeometry{T}}) where {T} = AG.centroid.(v)
+AG.getx(v::Vector{AG.IGeometry{T}}, i::I) where {T, I} = AG.getx.(v, i)
+AG.gety(v::Vector{AG.IGeometry{T}}, i::I) where {T, I} = AG.gety.(v, i)
+
+getx(df::DataFrame) = AG.getx(AG.centroid.(df.geometry), 0)
+gety(df::DataFrame) = AG.gety(AG.centroid.(df.geometry), 0)
+centroids(df::DataFrame) = collect(zip(getx(df), gety(df)))
+
 AG.isempty(v::Vector{AG.IGeometry{T}}) where {T} = AG.isempty.(v)
 AG.isvalid(v::Vector{AG.IGeometry{T}}) where {T} = AG.isvalid.(v)
 AG.issimple(v::Vector{AG.IGeometry{T}}) where {T} = AG.issimple.(v)


### PR DESCRIPTION
Added convenience functions to extract geometry centroids without having to import ArchGDAL.

I just shoved these into the `export` file as I wasn't sure of the best place to put these, or even if this is in the scope of the package.