### PR TITLE
Fix empty layer handling.

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -86,7 +86,7 @@ function read(ds, layer)
                 ),
             )
         end
-        names, _ = AG.schema_names(AG.getfeaturedefn(first(table)))
+        names, x = AG.schema_names(AG.layerdefn(table))
         sr = AG.getspatialref(table)
         return DataFrame(table), names, sr
     end


### PR DESCRIPTION
Fixes #84. This should not error anymore, but gives

```julia
0×1 DataFrame
 Row │ ptr
     │ Ptr…
─────┴──────
```
Which is also wrong, see https://github.com/yeesian/ArchGDAL.jl/issues/440 for fixing that.