### PR TITLE
Add `reproject` on table, and derive crs from geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ df
 
 ### Reprojection
 ```julia
+#Either reproject the whole dataframe (which will set the correct metadata):
+dfr = reproject(df, EPSG(4326), EPSG(28992))
+
+# Or reproject the individual geometries only:
 df.geometry = reproject(df.geometry, EPSG(4326), EPSG(28992))
 10-element Vector{ArchGDAL.IGeometry{ArchGDAL.wkbPolygon}}:
  Geometry: POLYGON ((-472026.042542408 -4406233.59953401,-537 ... 401))

--- a/docs/src/tutorials/ops.md
+++ b/docs/src/tutorials/ops.md
@@ -25,7 +25,11 @@ df
 
 ## Reprojection
 ```julia
-df.geom = reproject(df.geom, EPSG(4326), EPSG(28992))
+#Either reproject the whole dataframe (which will set the correct metadata):
+dfr = reproject(df, EPSG(4326), EPSG(28992))
+
+# Or reproject the individual geometries only:
+df.geometry = reproject(df.geometry, EPSG(4326), EPSG(28992))
 10-element Vector{ArchGDAL.IGeometry{ArchGDAL.wkbPolygon}}:
  Geometry: POLYGON ((-472026.042542408 -4406233.59953401,-537 ... 401))
  Geometry: POLYGON ((-417143.506054105 -4395423.99277048,-482 ... 048))

--- a/src/GeoDataFrames.jl
+++ b/src/GeoDataFrames.jl
@@ -8,9 +8,6 @@ import GeoInterface
 using DataAPI
 using Reexport
 
-@reexport using Extents
-@reexport using GeoFormatTypes
-
 include("exports.jl")
 include("io.jl")
 include("utils.jl")

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -11,7 +11,43 @@
     createpolygon,
     createmultilinestring,
     createmultipolygon
-@reexport using ArchGDAL: reproject
+
+@reexport using Extents
+@reexport using GeoInterface: crs
+
+using GeoFormatTypes:
+    AbstractWellKnownText,
+    CoordSys,
+    CoordinateReferenceSystemFormat,
+    EPSG,
+    ESRIWellKnownText,
+    GML,
+    GeoFormat,
+    GeoFormatTypes,
+    GeometryFormat,
+    KML,
+    MixedFormat,
+    ProjJSON,
+    ProjString,
+    WellKnownBinary,
+    WellKnownText,
+    WellKnownText2 #=GeoJSON,=#
+export AbstractWellKnownText,
+    CoordSys,
+    CoordinateReferenceSystemFormat,
+    EPSG,
+    ESRIWellKnownText,
+    GML,
+    GeoFormat,
+    GeoFormatTypes,
+    GeometryFormat,
+    KML,
+    MixedFormat,
+    ProjJSON,
+    ProjString,
+    WellKnownBinary,
+    WellKnownText,
+    WellKnownText2 #=GeoJSON,=#
 
 AG.intersects(a::Vector{AG.IGeometry{T}}, b::Vector{AG.IGeometry{X}}) where {X, T} =
     AG.intersects.(a, b)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,12 +23,26 @@ end
 function getcrs(table)
     if GeoInterface.isfeaturecollection(table)
         return GeoInterface.crs(table)
-    elseif first(DataAPI.metadatasupport(typeof(table)))
+    end
+    crs = geomcrs(table)
+    if !isnothing(crs)
+        return crs
+    end
+    if first(DataAPI.metadatasupport(typeof(table)))
         crs = DataAPI.metadata(table, "GEOINTERFACE:crs", nothing)
         if isnothing(crs) # fall back to searching for "crs" as a string
             crs = DataAPI.metadata(table, "crs", nothing)
         end
         return crs
+    end
+    nothing
+end
+
+function geomcrs(table)
+    rows = Tables.rows(table)
+    geom_column = first(getgeometrycolumns(table))
+    if hasproperty(first(rows), geom_column)
+        return GeoInterface.crs(getproperty(first(rows), geom_column))
     else
         return nothing
     end
@@ -84,3 +98,59 @@ end
 GeoInterface.geometrycolumns(row::DataFrameRow) =
     GeoInterface.geometrycolumns(getfield(row, :df)) # get the parent of the row view
 GeoInterface.crs(row::DataFrameRow) = GeoInterface.crs(getfield(row, :df)) # get the parent of the row view
+
+"""
+    reproject(df::DataFrame, to_crs)
+
+Reproject the geometries in a DataFrame `df` to a new Coordinate Reference System `to_crs`, from the current CRS.
+See also [`reproject(df, from_crs, to_crs)`](@ref) and the in place version [`reproject!(df, to_crs)`](@ref).
+"""
+function reproject(df::DataFrame, to_crs)
+    reproject!(copy(df), to_crs)
+end
+
+"""
+    reproject(df::DataFrame, from_crs, to_crs)
+
+Reproject the geometries in a DataFrame `df` from the crs `from_crs` to a new crs `to_crs`.
+This overrides any current CRS of the Dataframe.
+"""
+function reproject(df::DataFrame, from_crs, to_crs)
+    reproject!(copy(df), from_crs, to_crs)
+end
+
+"""
+    reproject!(df::DataFrame, to_crs)
+
+Reproject the geometries in a DataFrame `df` to a new Coordinate Reference System `to_crs`, from the current CRS, in place.
+"""
+function reproject!(df::DataFrame, to_crs)
+    reproject!(df, getcrs(df), to_crs)
+end
+
+"""
+    reproject!(df::DataFrame, from_crs, to_crs)
+
+Reproject the geometries in a DataFrame `df` from the crs `from_crs` to a new crs `to_crs` in place.
+This overrides any current CRS of the Dataframe.
+"""
+function reproject!(df::DataFrame, from_crs, to_crs)
+    columns = Tables.columns(df)
+    for gc in getgeometrycolumns(df)
+        gc in Tables.columnnames(columns) || continue
+        reproject(df[!, gc], from_crs, to_crs)
+    end
+    metadata!(df, "crs", to_crs; style = :note)
+    metadata!(df, "GEOINTERFACE:crs", to_crs; style = :note)
+end
+
+function reproject(sv::AbstractVector{<:AG.IGeometry}, from_crs, to_crs)
+    Base.depwarn(
+        "`reproject(sv::AbstractVector)` will be deprecated in a future release." *
+        "Please use `reproject(df::DataFrame)` instead to make sure the dataframe crs metadata is updated.",
+        :reproject,
+    )
+    AG.reproject.(sv, Ref(from_crs), Ref(to_crs))
+end
+
+export reproject, reproject!


### PR DESCRIPTION
Like the previous releases, this still clashes on `reproject` with GeometryOps, but at least operates on a table now, instead of on a column only (and forgetting to set the crs metadata on the table).

This also enables writing using the crs of the (first) geometry in the table.