### PR TITLE
Fix spelling and grammar in documentation

### DIFF
--- a/docs/src/background/todo.md
+++ b/docs/src/background/todo.md
@@ -3,5 +3,5 @@
 The following features are planned for future releases:
 
 - Prepared geometry to speed up repeated GDAL operations.
-- Spatial indice support to speed up spatial queries (see also [GeoAcceleratedArrays.jl](https://github.com/evetion/GeoAcceleratedArrays.jl))
+- Spatial index support to speed up spatial queries (see also [GeoAcceleratedArrays.jl](https://github.com/evetion/GeoAcceleratedArrays.jl))
 - Spatial joins (see also [GeometryOps.jl](https://github.com/JuliaGeo/GeometryOps.jl))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -106,7 +106,7 @@ using GeoDataFrames, GeoArrow
 
 ::: info Bugs, errors and making issues for GeoDataFrames.jl
 
-Because there are so many vector file types and variations of them, most of the time we need the `exact file` that caused your problem to know how to fix it, and be sure that we have actually fixed it when we are done. So fixing a GeoDataFrames.jl bug nearly always involves downloading some file and running some code that breaks with it (if you can trigger the bug without a file, that's great! but its not always possible).
+Because there are so many vector file types and variations of them, most of the time we need the `exact file` that caused your problem to know how to fix it, and be sure that we have actually fixed it when we are done. So fixing a GeoDataFrames.jl bug nearly always involves downloading some file and running some code that breaks with it (if you can trigger the bug without a file, that's great! but it's not always possible).
 
 To make an issue we can fix quickly (or at all) there are three key steps:
 1. Include the file in an accessible place on web `without authentication` or any other work on our part, so we can just get it and find your bug. You can put it on a file hosting platform (e.g. google drive, drop box, whatever you use) and share the url.

--- a/docs/src/tutorials/formats.md
+++ b/docs/src/tutorials/formats.md
@@ -23,7 +23,7 @@ GeoDataFrames.write("test.foo", df)
 ERROR: ArgumentError: There are no GDAL drivers for the .foo extension
 ```
 
-You can specifiy the GDAL driver using a keyword as follows:
+You can specify the GDAL driver using a keyword as follows:
 ```julia
 GeoDataFrames.write("test.foo", df; driver="GeoJSON")
 ```

--- a/docs/src/tutorials/ops.md
+++ b/docs/src/tutorials/ops.md
@@ -88,7 +88,7 @@ dfr = GeometryOps.reproject(df, EPSG(4326), EPSG(28992))
   10 │ (-458280.0, -5.72039e6)   test
 ```
 
-Note that by using GeometryOps, point geometries are reproject to a tuple of coordinates, which is treated as a valid Point geometry.
+Note that by using GeometryOps, point geometries are reprojected to a tuple of coordinates, which is treated as a valid Point geometry.
 
 ## Plotting
 

--- a/docs/src/tutorials/usage.md
+++ b/docs/src/tutorials/usage.md
@@ -55,7 +55,7 @@ GeoDataFrames.read("test.csv", options=["GEOM_POSSIBLE_NAMES=point,linestring", 
 
 
 ## Writing
-Write a DataFrame is done by the [`write`](@ref) function. It simply takes a filename, and a DataFrame with a geometry column.
+Writing a DataFrame is done by the [`write`](@ref) function. It simply takes a filename, and a DataFrame with a geometry column.
 
 ```julia
 points = GeoInterface.Point.(rand(10), rand(10))


### PR DESCRIPTION
- "its" → "it's" in index.md
- "specifiy" → "specify" in formats.md
- "reproject" → "reprojected" in ops.md
- "indice" → "index" in todo.md
- "Write a DataFrame" → "Writing a DataFrame" in usage.md