### PR TITLE
Cleanup

### DIFF
--- a/ext/GeoDataFramesGeoArrowExt.jl
+++ b/ext/GeoDataFramesGeoArrowExt.jl
@@ -10,7 +10,17 @@ using GeoArrow
 Read `fn` using the GeoArrowDriver driver. Any additional keyword arguments are passed to `Arrow.read`.
 """
 function GeoDataFrames.read(::GeoArrowDriver, fname::AbstractString; kwargs...)
-    GeoArrow.read(fname; kwargs...)
+    df = GeoArrow.read(fname; kwargs...)
+    GeoDataFrames.metadata!(
+        df,
+        "GEOINTERFACE:geometrycolumns",
+        GeoDataFrames.getgeometrycolumns(df);
+        style=:note,
+    )
+    for geom in GeoDataFrames.getgeometrycolumns(df)
+        df[!, geom] = collect(df[!, geom])
+    end
+    return df
 end
 
 """
@@ -18,8 +28,8 @@ end
 
 Write the provided `table` to `fn` using the GeoArrowDriver driver. Any additional keyword arguments are passed to `Arrow.write`.
 """
-function GeoDataFrames.write(::GeoArrowDriver, fname::AbstractString, data; kwargs...)
-    GeoArrow.write(fname, data; kwargs...)
+function GeoDataFrames.write(::GeoArrowDriver, fname::AbstractString, table; kwargs...)
+    GeoArrow.write(fname, table; kwargs...)
 end
 
 end

--- a/src/drivers.jl
+++ b/src/drivers.jl
@@ -50,7 +50,7 @@ function driver(ext::AbstractString)
         return ShapefileDriver()
     elseif ext in (".parquet", ".pq")
         return GeoParquetDriver()
-    elseif ext == (".arrow", ".feather")
+    elseif ext in (".arrow", ".feather")
         return GeoArrowDriver()
     elseif ext == ".fgb"
         return FlatGeobufDriver()

--- a/src/io.jl
+++ b/src/io.jl
@@ -392,19 +392,9 @@ const lookup_method = Dict{DataType, Function}(
     GI.MultiPolygonTrait => AG.unsafe_createmultipolygon,
 )
 
-const lookup_empty_method = Dict{DataType, Function}(
-    GI.PointTrait => AG.createpoint,
-    GI.MultiPointTrait => AG.createmultipoint,
-    GI.LineStringTrait => AG.createlinestring,
-    GI.LinearRingTrait => AG.createlinearring,
-    GI.MultiLineStringTrait => AG.createmultilinestring,
-    GI.PolygonTrait => AG.createpolygon,
-    GI.MultiPolygonTrait => AG.createmultipolygon,
-)
-
-function _convert(::Type{T}, geom) where {T <: AG.Geometry}
+function _convert(::Type{T}, geom) where {T<:AG.Geometry}
     trait = GI.geomtrait(geom)
-    f = get(GI.isempty(geom) ? lookup_empty_method : lookup_method, typeof(trait), nothing)
+    f = get(lookup_method, typeof(trait), nothing)
     isnothing(f) && error(
         "Cannot convert an object of $(typeof(geom)) with the $T trait (yet). Please report an issue.",
     )

--- a/src/io.jl
+++ b/src/io.jl
@@ -206,6 +206,16 @@ function write(
 )
     rows = Tables.rows(table)
     sch = Tables.schema(rows)
+    if isnothing(sch)
+        sch = Tables.schema(Tables.columns(table))
+    end
+    if isnothing(sch)
+        throw(
+            ArgumentError(
+                "Can't determine the schema of $(typeof(table)); provide a Tables.jl source with a discoverable row or column schema.",
+            ),
+        )
+    end
 
     # Determine geometry columns
     if !isnothing(geom_columns)  # backwards compatible
@@ -243,8 +253,9 @@ function write(
     end
 
     # Set geometry name in options
-    if !("geometry_name" in keys(options))
-        options["geometry_name"] = String(first(geometry_columns))
+    layer_options = copy(options)
+    if !("geometry_name" in keys(layer_options))
+        layer_options["geometry_name"] = String(first(geometry_columns))
     end
 
     # Find driver
@@ -294,7 +305,7 @@ function write(
                 dataset = can_create_layer ? ds : AG.create(AG.getdriver("Memory")),
                 geom = first(geom_types),  # how to set the name though?
                 spatialref = spatialref,
-                options = stringlist(options),
+                options = stringlist(layer_options),
             ) do layer
                 for (i, (geom_column, geom_type)) in
                     enumerate(zip(geometry_columns, geom_types))
@@ -321,14 +332,15 @@ function write(
 
                     for row in chunk
                         AG.addfeature(layer) do feature
-                            for (i, (geom_column)) in enumerate(geometry_columns)
+                            for (i, geom_column) in enumerate(geometry_columns)
+                                geometry = Tables.getcolumn(row, geom_column)
+                                if ismissing(geometry)
+                                    continue
+                                end
                                 AG.GDAL.ogr_f_setgeomfielddirectly(
                                     feature.ptr,
                                     i - 1,
-                                    _convert(
-                                        AG.Geometry,
-                                        Tables.getcolumn(row, geom_column),
-                                    ),
+                                    _convert(AG.Geometry, geometry),
                                 )
                             end
                             for (i, (name, _)) in zip(fieldindices, fields)
@@ -357,7 +369,7 @@ function write(
                         layer;
                         dataset = ds,
                         name = layer_name,
-                        options = stringlist(options),
+                        options = stringlist(layer_options),
                     )
                     if DataAPI.metadatasupport(typeof(table)).read
                         setmetadatalayer!(nlayer, table)
@@ -380,12 +392,23 @@ const lookup_method = Dict{DataType, Function}(
     GI.MultiPolygonTrait => AG.unsafe_createmultipolygon,
 )
 
+const lookup_empty_method = Dict{DataType, Function}(
+    GI.PointTrait => AG.createpoint,
+    GI.MultiPointTrait => AG.createmultipoint,
+    GI.LineStringTrait => AG.createlinestring,
+    GI.LinearRingTrait => AG.createlinearring,
+    GI.MultiLineStringTrait => AG.createmultilinestring,
+    GI.PolygonTrait => AG.createpolygon,
+    GI.MultiPolygonTrait => AG.createmultipolygon,
+)
+
 function _convert(::Type{T}, geom) where {T <: AG.Geometry}
-    f = get(lookup_method, typeof(GI.geomtrait(geom)), nothing)
+    trait = GI.geomtrait(geom)
+    f = get(GI.isempty(geom) ? lookup_empty_method : lookup_method, typeof(trait), nothing)
     isnothing(f) && error(
         "Cannot convert an object of $(typeof(geom)) with the $T trait (yet). Please report an issue.",
     )
-    return f(GI.coordinates(geom))
+    return GI.isempty(geom) ? f() : f(GI.coordinates(geom))
 end
 
 function _convert(::Type{T}, geom::AG.IGeometry) where {T <: AG.Geometry}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -128,10 +128,10 @@ function GI.properties(row::DataFrameRow)
     return row[DataFrames.Not(first(GI.geometrycolumns(row)))]
 end
 
-# Since `DataFrameRow` is simply a view of a DataFrame, we can reach back 
+# Since `DataFrameRow` is simply a view of a DataFrame, we can reach back
 # to the original DataFrame to get the metadata.
-GI.geometrycolumns(row::DataFrameRow) = GI.geometrycolumns(getfield(row, :df)) # get the parent of the row view
-GI.crs(row::DataFrameRow) = GI.crs(getfield(row, :df)) # get the parent of the row view
+GI.geometrycolumns(row::DataFrameRow) = GI.geometrycolumns(parent(row))
+GI.crs(row::DataFrameRow) = GI.crs(parent(row))
 
 """
     setgeometrycolumn!(df::DataFrame, column::Symbol)

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -29,7 +29,10 @@ Base.getindex(G::GeometryVector, i::Int) = getindex(parent(G), i)
 Base.setindex!(G::GeometryVector, v, i::Int) = setindex!(parent(G), v, i)
 
 # https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array
-Base.similar(G::GeometryVector, ::Type{T}, dims::Dims) where {T} = GeometryVector(similar(parent(G), T, dims))
+function Base.similar(G::GeometryVector, ::Type{T}, dims::Dims) where {T}
+    A = similar(parent(G), T, dims)
+    length(dims) == 1 ? GeometryVector(A) : A
+end
 
 # Mutable array interface
 # TODO Invalidate spatial index on mutations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -519,8 +519,8 @@ end
     @test_broken !isnothing(GI.crs(df))  # file has no crs
     @test "GEOINTERFACE:geometrycolumns" in keys(GDF.metadata(df))
 
-    @test_broken GDF.write("test_native.arrow", df) == "test_native.arrow"
-    @test_broken GDF.write(GDF.ArchGDALDriver(), "test.arrow", df) == "test.arrow"
+    @test GDF.write("test_native.arrow", df) == "test_native.arrow"
+    @test GDF.write(GDF.ArchGDALDriver(), "test.arrow", df) == "test.arrow"
     GDF.write(GDF.ArchGDALDriver(), "test.arrow", df2)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,9 @@ end
 end
 
 @testitem "Drivers" setup = [Setup] begin
+    @test GDF.driver(".arrow") isa GDF.GeoArrowDriver
+    @test GDF.driver(".feather") isa GDF.GeoArrowDriver
+
     t = GDF.read(fn; layer = 0)
     GDF.write(joinpath(testdatadir, "test.csv"), t)
     GDF.write(joinpath(testdatadir, "test.arrow"), t)
@@ -100,6 +103,26 @@ end
     @test nrow(t) == 2
     @test "name" in names(t)
     @test t.name[1] == "test"
+    @test ismissing(t.name[2])
+end
+
+@testitem "Write GeoPackage with NULLs" setup = [Setup] begin
+    import DataFrames
+
+    fnn = joinpath(testdatadir, "null_geometry_regression.gpkg")
+    table = DataFrames.DataFrame(
+        geometry=[AG.createpoint(1.0, 2.0), missing],
+        name=["test", missing],
+    )
+
+    GDF.write(fnn, table)
+    t = GDF.read(fnn)
+    @test size(t, 1) == 2
+    @test !ismissing(t.geometry[1])
+    @test GI.getcoord(t.geometry[1], 1) == 1.0
+    @test GI.getcoord(t.geometry[1], 2) == 2.0
+    @test t.name[1] == "test"
+    @test ismissing(t.geometry[2])
     @test ismissing(t.name[2])
 end
 
@@ -240,6 +263,67 @@ end
             "DESCRIPTION" => "Written by GeoDataFrames.jl",
         ),
         geometrycolumn = :foo,
+    )
+
+    options = Dict("DESCRIPTION" => "Reusable options")
+    GDF.write(
+        joinpath(testdatadir, "test_options5.gpkg"),
+        table;
+        options,
+        geometrycolumn = :foo,
+    )
+    @test options == Dict("DESCRIPTION" => "Reusable options")
+end
+
+@testitem "Write schemaless Tables source" setup = [Setup] begin
+    import Tables
+
+    struct SchemalessPointTable{R}
+        rows::R
+    end
+
+    Base.iterate(table::SchemalessPointTable, state...) = iterate(table.rows, state...)
+    Base.IteratorSize(::Type{<:SchemalessPointTable}) = Base.SizeUnknown()
+    Tables.istable(::Type{<:SchemalessPointTable}) = true
+    Tables.rowaccess(::Type{<:SchemalessPointTable}) = true
+    Tables.rows(table::SchemalessPointTable) = table
+    Tables.schema(::SchemalessPointTable) = nothing
+
+    table = SchemalessPointTable([
+        (; geometry = AG.createpoint(1.0, 2.0), name = "test"),
+    ])
+    @test Tables.schema(Tables.rows(table)) === nothing
+
+    fn = joinpath(testdatadir, "test_schemaless.gpkg")
+    result = try
+        GDF.write(fn, table)
+    catch err
+        err
+    end
+    @test result == fn
+    if result == fn
+        written = GDF.read(fn)
+        @test nrow(written) == 1
+        @test written.name == ["test"]
+    end
+
+    struct UndiscoverableSchemaPointTable{R}
+        rows::R
+    end
+
+    Base.iterate(table::UndiscoverableSchemaPointTable, state...) =
+        iterate(table.rows, state...)
+    Base.IteratorSize(::Type{<:UndiscoverableSchemaPointTable}) = Base.SizeUnknown()
+    Tables.istable(::Type{<:UndiscoverableSchemaPointTable}) = true
+    Tables.rowaccess(::Type{<:UndiscoverableSchemaPointTable}) = true
+    Tables.rows(table::UndiscoverableSchemaPointTable) = table
+    Tables.columns(table::UndiscoverableSchemaPointTable) = table
+    Tables.schema(::UndiscoverableSchemaPointTable) = nothing
+
+    no_schema_table = UndiscoverableSchemaPointTable(table.rows)
+    @test_throws ArgumentError GDF.write(
+        joinpath(testdatadir, "test_undiscoverable_schema.gpkg"),
+        no_schema_table,
     )
 end
 
@@ -417,19 +501,27 @@ end
 @testitem "GeoArrow" setup = [Setup] begin
     using GeoArrow
     fn = joinpath(testdatadir, "example-multipolygon_z.arrow")
+    native_df = GDF.read(GDF.GeoArrowDriver(), fn)
+    @test native_df.geometry isa Vector
+
     df = GDF.read(fn)
     AG.setconfigoption("OGR_ARROW_ALLOW_ALL_DIMS", "YES")
     df2 = GDF.read(GDF.ArchGDALDriver(), fn)
+    @test df.geometry isa GDF.GeometryVector
+    @test parent(df.geometry) isa Vector
+    @test eltype(df.geometry) != eltype(df2.geometry)
     @test sort(names(df)) == sort(names(df2))
     @test nrow(df) == nrow(df2)
     @test GI.trait(df.geometry[1]) == GI.trait(df2.geometry[1])
+
     @test GI.coordinates(df.geometry[1]) == GI.coordinates(df2.geometry[1])
 
-    # @test !isnothing(GI.crs(df))  # file has no crs
+    @test_broken !isnothing(GI.crs(df))  # file has no crs
     @test "GEOINTERFACE:geometrycolumns" in keys(GDF.metadata(df))
 
-    GDF.write("test_native.arrow", df)
-    GDF.write(GDF.ArchGDALDriver(), "test.arrow", df)
+    @test_broken GDF.write("test_native.arrow", df) == "test_native.arrow"
+    @test_broken GDF.write(GDF.ArchGDALDriver(), "test.arrow", df) == "test.arrow"
+    GDF.write(GDF.ArchGDALDriver(), "test.arrow", df2)
 end
 
 @testitem "Combination of drivers" setup = [Setup] begin
@@ -550,6 +642,14 @@ end
     filter!(row -> row.value > 5, df2)
     @test nrow(df2) == 5
     @test length(df2.geometry) == 5
+
+    mat = similar(gv, Int, (2, 3))
+    @test mat isa Matrix{Int}
+    @test size(mat) == (2, 3)
+
+    broadcasted = gv .== permutedims(gv)
+    @test broadcasted isa AbstractMatrix{Bool}
+    @test size(broadcasted) == (length(gv), length(gv))
 end
 
 @testitem "Metadata" setup = [Setup] begin


### PR DESCRIPTION
- Error on schemaless tables
- Fix writing empty geometries
- Fix native arrow detection
- Don't mutate driver options
- Fix DataFrameRow field access
- Fix GeometryVector becoming 2d with similar
