### PR TITLE
Improve read errors (and vsi handling)

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -67,9 +67,9 @@ julia> names(df2)
 function read(fn; kwargs...)
     gfn = _gdal_path(fn)
     ext = last(splitext(fn))
-    # Force ArchGDALDriver for paths rewritten to GDAL virtual filesystems,
-    # since native drivers can't handle /vsi* paths.
-    dr = gfn == fn ? driver(ext) : ArchGDALDriver()
+    # Native drivers cannot handle GDAL virtual filesystem paths, including
+    # paths explicitly supplied with a /vsi* prefix.
+    dr = gfn == fn && !startswith(gfn, "/vsi") ? driver(ext) : ArchGDALDriver()
     df = read(dr, gfn; kwargs...)
     for geom in getgeometrycolumns(df)
         df[!, geom] = GeometryVector(df[!, geom])
@@ -95,10 +95,16 @@ By default you only get the first layer, unless you specify either the index (0 
 Other supported kwargs are passed to the [ArchGDAL read](https://yeesian.com/ArchGDAL.jl/stable/reference/#ArchGDAL.read-Tuple{AbstractString}) method.
 The `options` keyword argument can be used to pass GDAL open options. Returns a `DataFrame`.
 """
-function read(driver::ArchGDALDriver, fn::AbstractString; layer = nothing, kwargs...)
+function read(
+    driver::ArchGDALDriver,
+    fn::AbstractString;
+    layer=nothing,
+    flags=AG.OF_READONLY | AG.OF_VERBOSE_ERROR,
+    kwargs...,
+)
     fn = _gdal_path(fn)
     _isvalidlocal(fn) || error("Can't find local file $fn.")
-    t = AG.read(fn; kwargs...) do ds
+    t = AG.read(fn; flags, kwargs...) do ds
         ds.ptr == C_NULL && error("Unable to open $fn.")
         if AG.nlayer(ds) > 1 && isnothing(layer)
             @warn "This file has multiple layers, defaulting to first layer."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,22 @@ end
     @test_throws ErrorException("Can't find local file /bla.shp.") GDF.read(fne)
 end
 
+@testitem "Read error includes GDAL diagnostic" setup = [Setup] begin
+    path = "/vsimem/missing.geojson"
+    exception = try
+        GDF.read(path)
+        nothing
+    catch caught
+        caught
+    end
+
+    @test exception isa AG.GDAL.GDALError
+    @test occursin(
+        "No such file or directory",
+        sprint(showerror, exception),
+    )
+end
+
 @testitem "Read shapefile with layer id" setup = [Setup] begin
     t = GDF.read(fn; layer = 0)
     @test nrow(t) == 42
@@ -711,6 +727,20 @@ end
     # Extension must be at a path boundary, not mid-word
     @test GDF._gdal_path("my.zipcode") == "my.zipcode"
     @test GDF._gdal_path("my.gzip") == "my.gzip"
+end
+
+@testitem "Read explicit GDAL virtual filesystem path" setup = [Setup] begin
+    import DataFrames
+    import GeoJSON
+
+    path = "/vsimem/explicit.geojson"
+    table = DataFrames.DataFrame(geometry=[AG.createpoint(1.0, 2.0)], value=[1])
+    GDF.write(GDF.ArchGDALDriver(), path, table; driver="GeoJSON")
+
+    df = GDF.read(path)
+    @test DataFrames.nrow(df) == 1
+    @test df.value == [1]
+    @test df.geometry[1] isa AG.IGeometry
 end
 
 @testitem "Read remote file via vsicurl" setup = [Setup] tags = [:network] begin


### PR DESCRIPTION
- Makes sure to read networked paths with GDAL
- Throw read errors by default now, instead of the unhelpful "Unable to open file."